### PR TITLE
Add nautilus-gnome-terminal-extension package

### DIFF
--- a/gnome-x64.packages
+++ b/gnome-x64.packages
@@ -78,3 +78,4 @@ Adapta
 papirus-icon-theme
 gnome-themes-standard
 adwaita-icon-theme
+nautilus-gnome-terminal-extension


### PR DESCRIPTION
Given that gnome-terminal is already installed as a dep of the gnome meta package, it makes sense to add the integration extension to nautilus.